### PR TITLE
feat(support): support Node.js v6.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ notifications:
   email: false
 node_js:
   - '8'
+  - '6'
 before_script:
   - npm prune
 after_success:

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const promisify = require('util').promisify
+const promisify = require('util-promisify')
 
 class PromiseModule {
   constructor (mod) {
@@ -13,9 +13,7 @@ const handler = {
     if (target.mod[name]) {
       let val
       if (typeof target.mod[name] === 'function') {
-        val = async (...args) => {
-          return promisify(cb => target.mod[name](...args, cb))()
-        }
+        val = (...args) => promisify(cb => target.mod[name](...args, cb))()
       } else {
         val = target.mod[name]
       }

--- a/package.json
+++ b/package.json
@@ -30,5 +30,11 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/mikeal/promwrap.git"
+  },
+  "dependencies": {
+    "util-promisify": "^2.1.0"
+  },
+  "engines": {
+    "node": ">=6.0.0"
   }
 }

--- a/test/test-basics.js
+++ b/test/test-basics.js
@@ -4,13 +4,15 @@ const promwrap = require('../')
 let fun = (x, cb) => cb(null, x)
 let _module = {fun, prop: 'test'}
 
-test('test basics', async t => {
+test('test basics', t => {
   t.plan(4)
   let mod = promwrap(_module)
   t.same(mod.prop, 'test')
   t.same(mod.prop, 'test')
-  t.same(await mod.fun('test1'), 'test1')
-  t.same(await promwrap(fun)('test2'), 'test2')
+  return Promise.all([
+    mod.fun('test1').then(res => t.same(res, 'test1')),
+    promwrap(fun)('test2').then(res => t.same(res, 'test2'))
+  ])
 })
 
 test('test error', t => {


### PR DESCRIPTION
I like `promwrap` more than literally *every other utility* I've tried to use which purports to do the same thing.  This is exactly what `Proxy` is for; it provides a safe wrapper into an object instead of trying to monkeypatch it... which doesn't work with things like `net.Server` instances.

I thought you might accept this.  I wanted to use `promwrap` in a project that targets Node.js v6.x.  The tradeoff: it adds a shim for `util.promisify`.  

But if we're adding a dep *anyway*, it may be worth considering pulling in a userland function-promisifier that doesn't *only* run in Node.js?

* * *

- pulls in userland `util.promisify` shim
(https://npm.im/util-promisify)
- avoid `async` keyword
- add version 6 check to CI